### PR TITLE
Fix handling of counter metrics

### DIFF
--- a/lib/telemetry_metrics_statman.ex
+++ b/lib/telemetry_metrics_statman.ex
@@ -65,8 +65,10 @@ defmodule TelemetryMetricsStatman do
     report(metric, key, round(value))
   end
 
-  defp report(%Metrics.Counter{}, key, value),
-    do: :statman.incr(key, value)
+  defp report(%Metrics.Counter{}, key, _value),
+  # As per documentation of Telemetry.Metrics.counter,
+  # ignore measurement and always increment by one.
+    do: :statman.incr(key, 1)
 
   defp report(%Metrics.Sum{}, key, value),
     do: :statman_gauge.incr(key, value)


### PR DESCRIPTION
According to the Telemetry.Metrics documentation, a counter metrics
should always be incremented by one for each event, regardless of the
actual value of the measurement.