### PR TITLE
Do not bin values for distribution metrics

### DIFF
--- a/lib/telemetry_metrics_statman.ex
+++ b/lib/telemetry_metrics_statman.ex
@@ -80,7 +80,7 @@ defmodule TelemetryMetricsStatman do
     do: :statman_histogram.record_value(key, :statman_histogram.bin(value))
 
   defp report(%Metrics.Distribution{}, key, value),
-    do: :statman_histogram.record_value(key, :statman_histogram.bin(value))
+    do: :statman_histogram.record_value(key, value)
 
 
   defp metric_key(metric, [] = _tags, _metadata),


### PR DESCRIPTION
For summary metrics, we put values into "bins" of 1000 before entering
them into the histogram, which works well for durations in
milliseconds.  For distribution, let's keep the original values, so
that we can report discrete metrics.