### PR TITLE
Fix Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: elixir
-# fossa is Ubuntu 20.04
-dist: fossa
-elixir: '1.10.3'
-otp_release: '22.3.4'
-before_install:
-  - git config --global 'url.git@github.com:GameAnalytics.insteadOf' 'https://github.com/GameAnalytics'
+# focal is Ubuntu 20.04
+dist: focal
+elixir: '1.16.1'
+otp_release: '26.1'
 script:
     - mix test
     - travis_wait mix dialyzer


### PR DESCRIPTION
The magic word is "focal", not "fossa".  Also use Erlang 26.1 and Elixir 1.16.1 - old versions don't seem to be available to download any more.

Also no need to use SSH to access Github, since the statman repository is public.